### PR TITLE
Fix undefined variable in prompt generation

### DIFF
--- a/audio_prompting_targeted_fix.js
+++ b/audio_prompting_targeted_fix.js
@@ -1870,7 +1870,8 @@ Output ONLY a single, valid JSON object with the following structure: {"concept"
 
         try {
             console.log('[VideoFX Artisan] Making API call with params:', paramsForGeneration);
-            const apiResult = await callArtisanApiInternal(state.activeMode === 'generator' ? 'mainPromptGen' : 'sceneExtender', paramsForGeneration.description, paramsForGeneration);
+            const apiActionKey = state.activeMode === 'generator' ? 'mainPromptGen' : 'sceneExtender';
+            const apiResult = await callArtisanApiInternal(apiActionKey, paramsForGeneration.description, paramsForGeneration);
 
             if (state.activeMode === 'sceneExtender') {
                 if (typeof apiResult === 'string') { // Expecting plain text for scene extender


### PR DESCRIPTION
## Summary
- define `apiActionKey` before calling the API
- use the new variable so the undefined variable error no longer occurs

## Testing
- `node --check audio_prompting_targeted_fix.js`

------
https://chatgpt.com/codex/tasks/task_e_6842a1ec26848322b7e51d5eb7140cbd