### PR TITLE
Improve overlay placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Temp-
+
+This repository hosts a userscript called **Veo Prompt Artisan Helper**. The script provides an overlay UI for crafting prompts on the VideoFX site.
+
+The main file is `audio_prompting_targeted_fix.js`.
+

--- a/audio_prompting_targeted_fix.js
+++ b/audio_prompting_targeted_fix.js
@@ -1,4 +1,3 @@
-
 // ==UserScript==
 // @name         VideoFX Prompt Artisan Helper (React Parity Edition)
 // @namespace    https://labs.google/
@@ -2233,8 +2232,9 @@ Output ONLY a single, valid JSON object with the following structure: {"concept"
         overlayContainer.style.position = 'fixed';
         overlayContainer.style.width = windowState.width + 'px';
         overlayContainer.style.height = windowState.height + 'px';
-        overlayContainer.style.right = '20px';
+        overlayContainer.style.left = windowState.x + 'px';
         overlayContainer.style.top = windowState.y + 'px';
+        overlayContainer.style.right = 'auto';
         overlayContainer.style.zIndex = '9999';
         overlayContainer.style.borderRadius = '12px';
         overlayContainer.style.border = '1px solid rgba(255, 255, 255, 0.1)';
@@ -2242,7 +2242,8 @@ Output ONLY a single, valid JSON object with the following structure: {"concept"
         overlayContainer.style.backgroundColor = '#121212'; // Solid background, no blur
         overlayContainer.style.color = '#ffffff';
         overlayContainer.style.fontFamily = "'Google Sans Text', 'Google Sans', 'Space Grotesk', sans-serif";
-        overlayContainer.style.overflow = 'hidden';
+        // Allow dropdown menus to extend beyond the window without being clipped
+        overlayContainer.style.overflow = 'visible';
         overlayContainer.style.flexDirection = 'column';
         overlayContainer.style.minWidth = windowState.minWidth + 'px';
         overlayContainer.style.minHeight = windowState.minHeight + 'px';
@@ -2788,7 +2789,7 @@ Output ONLY a single, valid JSON object with the following structure: {"concept"
                 color: hsl(200, 12%, 95.1%);
                 -webkit-font-smoothing: antialiased;
                 -moz-osx-font-smoothing: grayscale;
-                overflow: hidden;
+                overflow: visible;
             }
             #${OVERLAY_ID} .custom-scrollbar::-webkit-scrollbar { width: 8px; height: 8px; }
             #${OVERLAY_ID} .custom-scrollbar::-webkit-scrollbar-track { background: hsla(0, 0%, 100%, 0.05); border-radius:4px; }


### PR DESCRIPTION
## Summary
- set overlay's left coordinate based on saved state
- fix dropdown clipping so the tools menu isn't covered

## Testing
- `node --check audio_prompting_targeted_fix.js`


------
https://chatgpt.com/codex/tasks/task_e_6842a3bdc5a08322a4221f9a2d5e06da